### PR TITLE
Make convenience function copy quietly

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Here filePath can be a path on the local file system (unix OR windows) or a URL.
 
 
 ## Copy
-You can also copy files or directories using:
+You can copy files or directories using:
 ```
 filecopy.Copy(outputPath, inputPath)
 ```

--- a/pkg/filecopy/copier.go
+++ b/pkg/filecopy/copier.go
@@ -19,6 +19,7 @@ package filecopy
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -72,7 +73,7 @@ type copier struct {
 	always succeeds.
 */
 func Copy(destPath string, srcPath string) error {
-	return NewCopier(os.Stdout, NewChecker()).Copy(destPath, srcPath)
+	return NewCopier(ioutil.Discard, NewChecker()).Copy(destPath, srcPath)
 }
 
 func NewCopier(log io.Writer, checker Checker) *copier {


### PR DESCRIPTION
The convenience function for copying directories turned out not to be very convenient because it logged all its activity, which messes up the output of CLIs. If anyone wants a “chatty” form of copy, they can use the underlying package directly and supply `os.Stdout` as a writer rather than `ioutil.Discard`.